### PR TITLE
Changed 'pull_request_target' to 'pull_request'

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,13 +56,13 @@ jobs:
       
       - name: Terraform Plan
         id: plan
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: make plan
         continue-on-error: true
       
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         env:
           PLAN: ${{ steps.plan.outputs.stdout }}
         with:


### PR DESCRIPTION
- Terraform plan was being skipped due to if condition targeting 'pull_request_target' instead of 'pull_request', the change made in the last fix.