### PR TITLE
Fix: Forked repo unable to use secrets

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -2,7 +2,7 @@
 name: "Terraform"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -56,13 +56,13 @@ jobs:
       
       - name: Terraform Plan
         id: plan
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         run: make plan
         continue-on-error: true
       
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         env:
           PLAN: ${{ steps.plan.outputs.stdout }}
         with:


### PR DESCRIPTION
- Forked repo was unable to use repo secrets.
- moving from `push_request` to `push_request_target`