### PR TITLE
Add Terraform configuration to deploy an EC2 instance on AWS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,23 @@
+module "ssh_security_group" {
+  source = "terraform-aws-modules/security-group/aws//modules/ssh"
+
+  name                = "ssh-server"
+  vpc_id              = var.vpc_id
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+}
+module "ec2_instance" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name = "nurd-test-keyner-olivo"
+
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [module.ssh_security_group.security_group_id]
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
+
+  tags = {
+    Terraform   = "true"
+    Environment = "test"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "ID of the newly created instance"
+  value       = module.ec2_instance.id
+}
+
+output "public_ip_address" {
+  description = "publicly accessible ip address as an output"
+  value       = module.ec2_instance.public_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  description = "AWS region where the instance will be deployed"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "key_name" {
+  description = "Name of the SSH key to be installed on the instance"
+  type        = string
+  default     = "MC_Key"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type (i.e size of the instance)"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "subnet_id" {
+  description = "ID of the subnet where the instance will be deployed"
+  type        = string
+  default     = "subnet-09e8461838cc756a7"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the instance will be deployed"
+  type        = string
+  default     = "vpc-03d615e0d60310f0f"
+}

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
This pull request introduces several changes to the Terraform configuration to set up an EC2 instance with SSH access in AWS. The key changes include the addition of new modules, output variables, input variables, and provider configuration.

### Modules and Resources:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R23): Added a module for creating an SSH security group and an EC2 instance with specified configurations, including instance type, key name, and tags.

### Outputs:

* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R1-R9): Added outputs to expose the instance ID and public IP address of the newly created EC2 instance.

### Variables:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR1-R29): Introduced variables for region, key name, instance type, subnet ID, and VPC ID with default values.

### Provider Configuration:

* [`version.tf`](diffhunk://#diff-d23282b8d99f755b99f417569927589c56be44f2473d58ba79623f91b08a3953R1-R12): Added provider configuration for AWS, specifying the required provider version and setting the region from a variable.