### PR TITLE
fix: Slack Notify

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,14 +22,20 @@ jobs:
       AWS_INSTANCE_TYPE: ${{ secrets.AWS_INSTANCE_TYPE }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-    
+
     steps:
       - name: Checkout Forked Repo
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-    
+
+      - name: Fetch PR Details
+        id: pr-details
+        run: |
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "PR_AUTHOR=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -43,24 +49,19 @@ jobs:
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/terraform
           chmod 600 ~/.ssh/terraform
           echo -e "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" >> ~/.ssh/config
-      
-      - name: Terraform Init
-        run: make init
 
-      - name: Terraform Validate
-        run: make validate
-
-      - name: Terraform Plan
-        run: make plan
-
-      - name: Terraform Apply
-        run: make apply
-
-      - name: Terraform Verify
+      - name: Terraform Workflow
         run: |
-          make verify || true
+          make init
+          make validate
+          make plan
+          make apply
+          make verify || echo "VERIFY_FAILED=true" >> $GITHUB_ENV
 
-      - name: Notify Slack on Failure
-        if: failure()
+      - name: Send Slack Notification
         run: |
-          ./slack_notify.sh "${{ secrets.SLACK_WEBHOOK_URL }}" "deploy-failed" "Terraform Deployment"
+          if [ "${VERIFY_FAILED}" = "true" ]; then
+            ./slack_notify.sh "${{ secrets.SLACK_WEBHOOK_URL }}" "deploy-failed" "Terraform Deployment" "${{ env.PR_AUTHOR }}" "PR #${{ env.PR_NUMBER }}"
+          else
+            ./slack_notify.sh "${{ secrets.SLACK_WEBHOOK_URL }}" "success" "Terraform Deployment" "${{ env.PR_AUTHOR }}" "PR #${{ env.PR_NUMBER }}"
+          fi

--- a/slack_notify.sh
+++ b/slack_notify.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-# Assigning arguments to variables
-WEBHOOK_URL=$1              # Slack webhook URL to send the message
-STATUS=$2                   # Status of the deployment process
-APP=${3:-"Terraform Deployment"} # Application name
-USERNAME=${4:-"Unknown User"}    # GitHub username of the PR author
-FULL_NAME=${5:-"Unknown Name"}   # Full name of the PR author
+WEBHOOK_URL=$1
+STATUS=$2
+APP=$3
+AUTHOR=${4:-"Unknown User"}
+PR_NUMBER=${5:-"N/A"}
 
-# Set appropriate messages and emojis based on the deployment status
 case $STATUS in
     success)
         MESSAGE=":white_check_mark: Verification for *${APP}* was successful!"
@@ -20,20 +18,18 @@ case $STATUS in
         ;;
 esac
 
-# Compose the Slack message
 NOTIFICATION="{
   \"attachments\": [
     {
       \"color\": \"$([ \"$STATUS\" == \"success\" ] && echo \"good\" || echo \"danger\")\",
-      \"pretext\": \"Terraform Workflow Result for PR #${GITHUB_PULL_REQUEST}\",
+      \"pretext\": \"Terraform Workflow Result for ${PR_NUMBER}\",
       \"text\": \"$MESSAGE\",
       \"fields\": [
-        {\"title\": \"Author\", \"value\": \"@$USERNAME\", \"short\": true},
-        {\"title\": \"Name\", \"value\": \"$FULL_NAME\", \"short\": true}
+        {\"title\": \"Author\", \"value\": \"@$AUTHOR\", \"short\": true},
+        {\"title\": \"PR\", \"value\": \"${PR_NUMBER}\", \"short\": true}
       ]
     }
   ]
 }"
 
-# Send the message to Slack via the webhook
 curl -X POST -H 'Content-type: application/json' --data "$NOTIFICATION" ${WEBHOOK_URL}


### PR DESCRIPTION
**Note**: the pipeline in the PR should intentionally fail. 

This PR fixes and improves the CI/CD pipeline and Slack integration as follows:
1. **Fetch PR Details**: Captures the PR number and author using GitHub Actions’ context.
2. **Error Handling**: If `make verify` fails, it sets `VERIFY_FAILED=true` in the environment so the Slack notification step still executes.
3. **Improved Slack Notification**:
    1. Adds PR author (`@username`) and PR number to the Slack notification.
    2. Handles both success and failure cases.

**Expected Slack Output**

**Success**:
✅ Verification for Terraform Deployment was successful! 
**Author**: @github_user
**PR**: PR #123

**Failure**:
❌ Verification for Terraform Deployment failed. Deployment terminated. 
**Author**: @github_user
**PR**: PR #123