### PR TITLE
Solution for Terraform EC2 challenge - dschacon288

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,78 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_ami" "base_ami" {
+  most_recent      = true
+  owners           = ["amazon"]
+ 
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+ 
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+ 
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+ 
+}
+
+resource "aws_security_group" "ec2-assesment-sg" {
+  name        = "ec2-assesment-sg"
+  description = "Security group for SSH, HTTP, and HTTPS access"
+
+  vpc_id = var.vpc_id
+  ingress {
+    description = "SSH Access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] ## Not recommended IPs should be restricted
+  }
+  ingress {
+    description = "HTTP Access"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    description = "HTTPS Access"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1" 
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "ec2-nurdsoft-assesment" {
+    ami           = "${data.aws_ami.base_ami.id}"
+    instance_type = var.instance_type
+    key_name      = var.key_name
+    subnet_id     = var.subnet_id
+    #Security options 
+    monitoring = true
+    ebs_optimized = true
+    metadata_options {
+         http_endpoint = "enabled"
+         http_tokens   = "required"
+    }  
+    root_block_device {
+        encrypted     = true
+    }
+    tags = {
+        Name = "assesment-Instance"
+    }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "InstanceId" {
+  value = aws_instance.ec2-nurdsoft-assesment.id
+}
+
+output "PublicIpAddress" {
+  value = aws_instance.ec2-nurdsoft-assesment.public_ip
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,4 @@ output "InstanceId" {
 output "PublicIpAddress" {
   value = aws_instance.ec2-nurdsoft-assesment.public_ip
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {}
+variable "key_name" {}
+variable "instance_type" {}
+variable "subnet_id" {}
+variable "vpc_id" {}


### PR DESCRIPTION
I used Terraform to deploy an AWS EC2 instance with a security group that allows:

- SSH (port 22) access.
- HTTP (port 80) and HTTPS (port 443) traffic.

I added variables for flexibility (region, key name, instance type, subnet, and VPC) and outputs to display the instance ID and public IP. The code was validated and tested using Terraform commands.